### PR TITLE
Upgrade Next.js dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "next-js-boilerplate",
   "version": "1.0.0",
   "engines": {
-    "npm": ">=9.8.0 <9.8.2",
-    "node": ">=19.7.0 <19.8.0"
+    "npm": ">=9.8.0",
+    "node": ">=18.17.0"
   },
   "scripts": {
     "dev": "next dev",
@@ -20,16 +20,16 @@
   "dependencies": {
     "classnames": "^2.3.1",
     "fathom-client": "^3.6.0",
-    "next": "^12.0.9",
-    "next-seo": "^4.29.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "styled-jsx-plugin-postcss": "^4.0.1"
+    "next": "^14.2.3",
+    "next-seo": "^6.5.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "styled-jsx-plugin-postcss": "^5.0.0"
   },
   "devDependencies": {
-    "@next/bundle-analyzer": "^12.0.9",
-    "@types/node": "^17.0.13",
-    "@types/react": "^17.0.38",
+    "@next/bundle-analyzer": "^14.2.3",
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.3.3",
     "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.10.1",
     "autoprefixer": "^10.4.2",
@@ -38,7 +38,7 @@
     "eslint": "^8.7.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^16.1.0",
-    "eslint-config-next": "^12.0.9",
+    "eslint-config-next": "^14.2.3",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",
@@ -53,7 +53,7 @@
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "tailwindcss": "^3.0.17",
-    "typescript": "^4.5.5"
+    "typescript": "^5.4.5"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
## Summary
- update Next.js, React, and related packages to current stable versions
- relax Node and npm engine constraints to allow modern environments

## Testing
- npm install *(fails: registry access returns HTTP 403 via proxy)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69352f16693c832c9c84089e013e1d02)